### PR TITLE
feat: Root Login screen ui (part 1)

### DIFF
--- a/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/RootLoginScreen.kt
+++ b/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/RootLoginScreen.kt
@@ -1,0 +1,98 @@
+package com.crisiscleanup.feature.authentication.ui
+
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.method.LinkMovementMethod
+import android.text.style.URLSpan
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.crisiscleanup.core.designsystem.LocalAppTranslator
+import com.crisiscleanup.core.designsystem.component.BusyButton
+import com.crisiscleanup.core.designsystem.component.CrisisCleanupOutlinedButton
+import com.crisiscleanup.core.designsystem.component.LinkifyText
+import com.crisiscleanup.core.designsystem.theme.CrisisCleanupTheme
+import com.crisiscleanup.core.designsystem.theme.DayNightPreviews
+import com.crisiscleanup.core.designsystem.theme.LocalFontStyles
+import com.crisiscleanup.core.designsystem.theme.fillWidthPadded
+import com.crisiscleanup.core.designsystem.theme.listItemModifier
+import com.crisiscleanup.feature.authentication.R
+
+
+@Composable
+internal fun RootLoginScreen() {
+    val translator = LocalAppTranslator.current
+    val isBusy = false
+    Text(
+        modifier = listItemModifier.testTag("loginHeaderText"),
+        text = translator("actions.login", R.string.login),
+        style = LocalFontStyles.current.header1,
+    )
+    BusyButton(
+        modifier = fillWidthPadded
+            .testTag("loginLoginWithEmailBtn"),
+        onClick = {},
+        enabled = !isBusy,
+        text = translator("~~Login with Email", R.string.loginWithEmail),
+        indicateBusy = isBusy,
+    )
+    BusyButton(
+        modifier = fillWidthPadded
+            .testTag("loginLoginWithPhoneBtn"),
+        onClick = {},
+        enabled = !isBusy,
+        text = translator("~~Login with Cell Phone", R.string.loginWithPhone),
+        indicateBusy = isBusy,
+    )
+    CrisisCleanupOutlinedButton(
+        modifier = fillWidthPadded
+            .testTag("loginVolunteerWithOrgBtn"),
+        onClick = {},
+        enabled = !isBusy,
+        text = translator("~~Volunteer with Your Org", R.string.volunteerWithYourOrg),
+    )
+    CrisisCleanupOutlinedButton(
+        modifier = fillWidthPadded
+            .testTag("loginNeedHelpCleaningBtn"),
+        onClick = {},
+        enabled = !isBusy,
+        text = translator("~~I need help cleaning up", R.string.iNeedHelpCleaningUp),
+    )
+    Column(
+        modifier = fillWidthPadded,
+    ) {
+        val linkText = translator("~~Register here", R.string.registerHere)
+        val spannableString = SpannableString(linkText).apply {
+            setSpan(
+                URLSpan("https://crisiscleanup.org/survivor"),
+                0,
+                length,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+        Text(
+            modifier = Modifier.testTag("loginReliefOrgAndGovText"),
+            text = translator(
+                "~~Relief organizations and government only.",
+                R.string.reliefOrgAndGovOnly,
+            ),
+        )
+        LinkifyText(
+            modifier = Modifier.testTag("loginRegisterHereLink"),
+            text = spannableString,
+            linkify = { textView ->
+                textView.movementMethod = LinkMovementMethod.getInstance()
+            },
+        )
+    }
+}
+
+@DayNightPreviews
+@Composable
+fun RootLoginScreenPreview() {
+    CrisisCleanupTheme {
+        RootLoginScreen()
+    }
+}

--- a/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/RootLoginScreen.kt
+++ b/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/RootLoginScreen.kt
@@ -1,5 +1,7 @@
 package com.crisiscleanup.feature.authentication.ui
 
+import android.content.Intent
+import android.net.Uri
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.method.LinkMovementMethod
@@ -10,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.crisiscleanup.core.designsystem.LocalAppTranslator
@@ -26,6 +29,7 @@ import com.crisiscleanup.feature.authentication.R
 
 @Composable
 internal fun RootLoginScreen() {
+    val ctx = LocalContext.current
     val translator = LocalAppTranslator.current
     val isBusy = false
     Text(
@@ -67,7 +71,11 @@ internal fun RootLoginScreen() {
             modifier = Modifier
                 .fillMaxWidth()
                 .testTag("loginNeedHelpCleaningBtn"),
-            onClick = {},
+            onClick = {
+                val openURL = Intent(Intent.ACTION_VIEW)
+                openURL.data = Uri.parse("https://crisiscleanup.org/survivor")
+                ctx.startActivity(openURL)
+            },
             enabled = !isBusy,
             text = translator("~~I need help cleaning up", R.string.iNeedHelpCleaningUp),
         )

--- a/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/RootLoginScreen.kt
+++ b/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/RootLoginScreen.kt
@@ -66,7 +66,7 @@ internal fun RootLoginScreen() {
         val linkText = translator("~~Register here", R.string.registerHere)
         val spannableString = SpannableString(linkText).apply {
             setSpan(
-                URLSpan("https://crisiscleanup.org/survivor"),
+                URLSpan("https://crisiscleanup.org/register"),
                 0,
                 length,
                 Spanned.SPAN_EXCLUSIVE_EXCLUSIVE

--- a/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/RootLoginScreen.kt
+++ b/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/RootLoginScreen.kt
@@ -4,11 +4,14 @@ import android.text.SpannableString
 import android.text.Spanned
 import android.text.method.LinkMovementMethod
 import android.text.style.URLSpan
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import com.crisiscleanup.core.designsystem.LocalAppTranslator
 import com.crisiscleanup.core.designsystem.component.BusyButton
 import com.crisiscleanup.core.designsystem.component.CrisisCleanupOutlinedButton
@@ -30,36 +33,45 @@ internal fun RootLoginScreen() {
         text = translator("actions.login", R.string.login),
         style = LocalFontStyles.current.header1,
     )
-    BusyButton(
-        modifier = fillWidthPadded
-            .testTag("loginLoginWithEmailBtn"),
-        onClick = {},
-        enabled = !isBusy,
-        text = translator("~~Login with Email", R.string.loginWithEmail),
-        indicateBusy = isBusy,
-    )
-    BusyButton(
-        modifier = fillWidthPadded
-            .testTag("loginLoginWithPhoneBtn"),
-        onClick = {},
-        enabled = !isBusy,
-        text = translator("~~Login with Cell Phone", R.string.loginWithPhone),
-        indicateBusy = isBusy,
-    )
-    CrisisCleanupOutlinedButton(
-        modifier = fillWidthPadded
-            .testTag("loginVolunteerWithOrgBtn"),
-        onClick = {},
-        enabled = !isBusy,
-        text = translator("~~Volunteer with Your Org", R.string.volunteerWithYourOrg),
-    )
-    CrisisCleanupOutlinedButton(
-        modifier = fillWidthPadded
-            .testTag("loginNeedHelpCleaningBtn"),
-        onClick = {},
-        enabled = !isBusy,
-        text = translator("~~I need help cleaning up", R.string.iNeedHelpCleaningUp),
-    )
+    Column(
+        modifier = fillWidthPadded,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        BusyButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("loginLoginWithEmailBtn"),
+            onClick = {},
+            enabled = !isBusy,
+            text = translator("~~Login with Email", R.string.loginWithEmail),
+            indicateBusy = isBusy,
+        )
+        BusyButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("loginLoginWithPhoneBtn"),
+            onClick = {},
+            enabled = !isBusy,
+            text = translator("~~Login with Cell Phone", R.string.loginWithPhone),
+            indicateBusy = isBusy,
+        )
+        CrisisCleanupOutlinedButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("loginVolunteerWithOrgBtn"),
+            onClick = {},
+            enabled = !isBusy,
+            text = translator("~~Volunteer with Your Org", R.string.volunteerWithYourOrg),
+        )
+        CrisisCleanupOutlinedButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("loginNeedHelpCleaningBtn"),
+            onClick = {},
+            enabled = !isBusy,
+            text = translator("~~I need help cleaning up", R.string.iNeedHelpCleaningUp),
+        )
+    }
     Column(
         modifier = fillWidthPadded,
     ) {
@@ -69,7 +81,7 @@ internal fun RootLoginScreen() {
                 URLSpan("https://crisiscleanup.org/register"),
                 0,
                 length,
-                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
             )
         }
         Text(

--- a/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/RootLoginScreen.kt
+++ b/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/RootLoginScreen.kt
@@ -1,7 +1,5 @@
 package com.crisiscleanup.feature.authentication.ui
 
-import android.content.Intent
-import android.net.Uri
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.method.LinkMovementMethod
@@ -12,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.crisiscleanup.core.designsystem.LocalAppTranslator
@@ -29,8 +27,8 @@ import com.crisiscleanup.feature.authentication.R
 
 @Composable
 internal fun RootLoginScreen() {
-    val ctx = LocalContext.current
     val translator = LocalAppTranslator.current
+    val uriHandler = LocalUriHandler.current
     val isBusy = false
     Text(
         modifier = listItemModifier.testTag("loginHeaderText"),
@@ -67,14 +65,13 @@ internal fun RootLoginScreen() {
             enabled = !isBusy,
             text = translator("~~Volunteer with Your Org", R.string.volunteerWithYourOrg),
         )
+        // TODO Open in WebView?
         CrisisCleanupOutlinedButton(
             modifier = Modifier
                 .fillMaxWidth()
                 .testTag("loginNeedHelpCleaningBtn"),
             onClick = {
-                val openURL = Intent(Intent.ACTION_VIEW)
-                openURL.data = Uri.parse("https://crisiscleanup.org/survivor")
-                ctx.startActivity(openURL)
+                uriHandler.openUri("https://crisiscleanup.org/survivor")
             },
             enabled = !isBusy,
             text = translator("~~I need help cleaning up", R.string.iNeedHelpCleaningUp),

--- a/feature/authentication/src/main/res/values/strings.xml
+++ b/feature/authentication/src/main/res/values/strings.xml
@@ -4,6 +4,12 @@
         If the first load is slow or an internet connection is not available translations without fallbacks will show the translation keys.
     -->
     <string name="login">Login</string>
+    <string name="loginWithEmail">Login with Email</string>
+    <string name="loginWithPhone">Login with Cell Phone</string>
+    <string name="volunteerWithYourOrg">Volunteer with your Org</string>
+    <string name="iNeedHelpCleaningUp">I need help cleaning up</string>
+    <string name="reliefOrgAndGovOnly">Relief organizations and government only.</string>
+    <string name="registerHere">Register here</string>
     <string name="email">Email</string>
     <string name="password">Password</string>
 </resources>


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the title above
- Describe your changes in detail
- What does this pull request add/fix? Explain your changes.
-->

## Description

Note: This screen isn't connected in UI. Its a standalone screen for now. Once all links are working, I will connect it in `AuthenticateScreen`

As per @arroyoDev, we should make the following changes for MVP:

- Clicking `I need help cleaning up` should navigate to `https://crisiscleanup.org/survivor`
- Clicking `Register Now` should open browser and navigate to `https://crisiscleanup.org/register`

If you wish to test it out locally, please apply the following patch

```diff
diff --git a/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/AuthenticateScreen.kt b/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/AuthenticateScreen.kt
index e0eae11b..bcdd7954 100644
--- a/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/AuthenticateScreen.kt
+++ b/feature/authentication/src/main/java/com/crisiscleanup/feature/authentication/ui/AuthenticateScreen.kt
@@ -145,11 +145,17 @@ private fun AuthenticateScreen(
                             onCloseScreen,
                         )
                     } else {
-                        LoginScreen(
-                            authState,
-                            openForgotPassword = openForgotPassword,
-                            openEmailMagicLink = openEmailMagicLink,
-                            closeAuthentication = onCloseScreen,
+//                        LoginScreen(
+//                            authState,
+//                            openForgotPassword = openForgotPassword,
+//                            openEmailMagicLink = openEmailMagicLink,
+//                            closeAuthentication = onCloseScreen,
+//                        )
+                        RootLoginScreen(
+//                            authState,
+//                            openForgotPassword,
+//                            openEmailMagicLink,
+//                            closeAuthentication,
                         )
 
                         Spacer(modifier = Modifier.weight(1f))
```

### Changelog

- feat(authentication): add more first slow load string values in strings.xml (5c6a13b2)
- feat(authentication): add RootLoginScreen.kt with root login screen ui elements (1c543042)
- fix(authentication): fix register here link in RootLoginScreen (e4f2feb1)
- fix(authentication): fix spacing on RootLoginScreen, wrap buttons in Column (daa78523)
- fix(authentication): open survivor page in default web browser on iNeedHelpCleaningBtn click (245729df)
- refactor(authentication): use LocalUriHandler instead of LocalContext to open survivor link (7f4d77a9)

## Screenshots

[pr72.webm](https://github.com/CrisisCleanup/crisiscleanup-android/assets/46167867/0c1953ab-189a-4c9e-88f8-ab5e55fb612d)


<!--
- This project only accepts pull requests related to open issues
- If suggesting a new feature or change, please discuss it in an issue first
- Does your pull request close any issue? If so, please provide a link to the issue.
- If your pull request references an issue, please provide a link to the issue.
-->

## Related Issue

Ref: #7

<!--
- Why is this change required?
- What problem does it solve?
-->
<!-- ## Motivation and Context -->

<!--
- What types of changes does your code introduce?
- Put an `x` in all the boxes that apply:
-->

## Pull Request Type

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes

<!--
- Go over all the following points, and put an `x` in all the boxes that apply.
- If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact of your change below. -->

<!--
- Provide additional context if necessary.
- Examples: version, OS, Browser, Other environment information, error logs, etc.
-->
<!-- ## Additional Context -->

